### PR TITLE
Make sure the body take 100% of the height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,7 +135,7 @@ export default {
   $text-color: #E3E5C9
   //@import url("assets/fonts/font-calamity") // bug: parsed by css :/
 
-  html
+  html, body
     height: 100%
 
   body

--- a/src/App.vue
+++ b/src/App.vue
@@ -137,9 +137,9 @@ export default {
 
   html, body
     height: 100%
+    background: #050F2C
 
   body
-    background: #050F2C
     color: $text-color
     font-family: Calamity, sans-serif
 


### PR DESCRIPTION
If we search for an item who have a few results, ex. "Phantom", we see that the background color is sliced because it take the size of the results container, not the full page height.

Put a `height: 100%` to the body make it work.
+ Set the `background-color` to the `html` tag.